### PR TITLE
fix metric: handling ignore index correctly

### DIFF
--- a/utils/metrics.py
+++ b/utils/metrics.py
@@ -39,14 +39,14 @@ class AverageMeter(object):
     def average(self):
         return np.round(self.avg, 5)
 
-def batch_pix_accuracy(output, target):
+def batch_pix_accuracy(output, target, num_class):
     _, predict = torch.max(output, 1)
 
     predict = predict.int() + 1
     target = target.int() + 1
 
-    pixel_labeled = (target > 0).sum()
-    pixel_correct = ((predict == target)*(target > 0)).sum()
+    pixel_labeled = (target <= num_class).sum()
+    pixel_correct = ((predict == target)*(target <= num_class)).sum()
     assert pixel_correct <= pixel_labeled, "Correct area should be smaller than Labeled"
     return pixel_correct.cpu().numpy(), pixel_labeled.cpu().numpy()
 
@@ -55,7 +55,7 @@ def batch_intersection_union(output, target, num_class):
     predict = predict + 1
     target = target + 1
 
-    predict = predict * (target > 0).long()
+    predict = predict * (target <= num_class).long()
     intersection = predict * (predict == target).long()
 
     area_inter = torch.histc(intersection.float(), bins=num_class, max=num_class, min=1)
@@ -65,28 +65,7 @@ def batch_intersection_union(output, target, num_class):
     assert (area_inter <= area_union).all(), "Intersection area should be smaller than Union area"
     return area_inter.cpu().numpy(), area_union.cpu().numpy()
 
-def eval_metrics(output, target, num_classes):
-    correct, labeled = batch_pix_accuracy(output.data, target)
-    inter, union = batch_intersection_union(output.data, target, num_classes)
+def eval_metrics(output, target, num_class):
+    correct, labeled = batch_pix_accuracy(output.data, target, num_class)
+    inter, union = batch_intersection_union(output.data, target, num_class)
     return [np.round(correct, 5), np.round(labeled, 5), np.round(inter, 5), np.round(union, 5)]
-
-
-
-def pixel_accuracy(output, target):
-    output = np.asarray(output)
-    target = np.asarray(target)
-    pixel_labeled = np.sum(target > 0)
-    pixel_correct = np.sum((output == target) * (target > 0))
-    return pixel_correct, pixel_labeled
-
-def inter_over_union(output, target, num_class):
-    output = np.asarray(output) + 1
-    target = np.asarray(target) + 1
-    output = output * (target > 0)
-
-    intersection = output * (output == target)
-    area_inter, _ = np.histogram(intersection, bins=num_class, range=(1, num_class))
-    area_pred, _ = np.histogram(output, bins=num_class, range=(1, num_class))
-    area_lab, _ = np.histogram(target, bins=num_class, range=(1, num_class))
-    area_union = area_pred + area_lab - area_inter
-    return area_inter, area_union


### PR DESCRIPTION
PR for #29

I did,
1.  Change variable name `num_classes -> num_class`.
2. Remove unused functions `pixel_accuracy`, `inter_over_union`.
3. Fix ignore-index condition correctly.

Because torch `long` is a larger type than `uint8`, there is no overflow. Therefore, `255 + 1` is `256` rather than 0.
To filter known classes, `(target > 0)` should be changed to `(target <= num_class)`. (ex. 1 ~ 21 for VOC) 