### PR TITLE
Update backbone initialization in DeepLab and UperNet models to include backbone parameter

### DIFF
--- a/models/ deeplabv3_plus_xception.py
+++ b/models/ deeplabv3_plus_xception.py
@@ -1009,7 +1009,7 @@ class DeepLab(BaseModel):
         super(DeepLab, self).__init__()
         assert ('xception' or 'resnet' in backbone)
         if 'resnet' in backbone:
-            self.backbone = ResNet(in_channels=in_channels, output_stride=output_stride, pretrained=pretrained)
+            self.backbone = ResNet(in_channels=in_channels, output_stride=output_stride, backbone=backbone, pretrained=pretrained)
             low_level_channels = 256
         else:
             self.backbone = xception_65(output_stride=output_stride, pretrained=pretrained,global_pool=False,checkpoint_path='./pretrained/xception_65.pth')

--- a/models/deeplabv3_plus.py
+++ b/models/deeplabv3_plus.py
@@ -340,7 +340,7 @@ class DeepLab(BaseModel):
         super(DeepLab, self).__init__()
         assert ('xception' or 'resnet' in backbone)
         if 'resnet' in backbone:
-            self.backbone = ResNet(in_channels=in_channels, output_stride=output_stride, pretrained=pretrained)
+            self.backbone = ResNet(in_channels=in_channels, output_stride=output_stride, backbone=backbone, pretrained=pretrained)
             low_level_channels = 256
         else:
             self.backbone = Xception(output_stride=output_stride, pretrained=pretrained)

--- a/models/upernet.py
+++ b/models/upernet.py
@@ -125,7 +125,7 @@ class UperNet(BaseModel):
             feature_channels = [64, 128, 256, 512]
         else:
             feature_channels = [256, 512, 1024, 2048]
-        self.backbone = ResNet(in_channels, pretrained=pretrained)
+        self.backbone = ResNet(in_channels, backbone=backbone, pretrained=pretrained)
         self.PPN = PSPModule(feature_channels[-1])
         self.FPN = FPN_fuse(feature_channels, fpn_out=fpn_out)
         self.head = nn.Conv2d(fpn_out, num_classes, kernel_size=3, padding=1)


### PR DESCRIPTION
The current ResNet initialization in the following files does not use the parameter `backbone`, so the different types of ResNet set by this parameter are invalid.

```
deeplabv3_plus_xception.py
deeplabv3_plus.py
upernet.py
```

This PR was submitted to fix the issue.